### PR TITLE
Dpcoords export and shellexpander env path fix

### DIFF
--- a/becas_wrapper/becas_bladestructure.py
+++ b/becas_wrapper/becas_bladestructure.py
@@ -131,6 +131,8 @@ class BECASCSStructure(Component):
         self.csprops_ref_m1 = np.zeros(cs_size_ref)
         self.k_matrix_m1 = np.zeros((6,6))
         self.m_matrix_m1 = np.zeros((6,6))
+        
+        self.add_output('%s:DPcoords' % name, np.zeros((self.nr + 1, 3)))
 
         self.workdir = 'becas_%s_%i' % (name, self.becas_hash)
         # not so nice hack to ensure unique directory names when
@@ -209,6 +211,9 @@ class BECASCSStructure(Component):
 
         self.mesher.cs2d = self.cs2d
         self.mesher.compute()
+        
+        self.unknowns['%s:DPcoords' % self.name][:,0:2] = np.array(self.mesher.DPcoords)
+        
         self.becas.compute()
         if self.becas.success:
             self.unknowns['%s:cs_props' % self.name] = self.becas.cs_props

--- a/becas_wrapper/becas_bladestructure.py
+++ b/becas_wrapper/becas_bladestructure.py
@@ -211,12 +211,11 @@ class BECASCSStructure(Component):
 
         self.mesher.cs2d = self.cs2d
         
-        self.unknowns['%s:DPcoords' % self.name][:,0:2] = np.array(self.mesher.DPcoords)
-        
         try:
             self.mesher.compute()
             self.becas.compute()
             if self.becas.success:
+                self.unknowns['%s:DPcoords' % self.name][:,0:2] = np.array(self.mesher.DPcoords)
                 self.unknowns['%s:cs_props' % self.name] = self.becas.cs_props
                 self.unknowns['%s:csprops_ref' % self.name] = self.becas.csprops
                 self.unknowns['%s:k_matrix' % self.name] = self.becas.k_matrix

--- a/becas_wrapper/cs2dtobecas.py
+++ b/becas_wrapper/cs2dtobecas.py
@@ -58,7 +58,6 @@ class CS2DtoBECAS(object):
     """
 
     def __init__(self, cs2d, **kwargs):
-        self.path_shellexpander = os.environ['SHELLEXP_BASEDIR']
         
         self.dry_run = False
         self.cs2d = cs2d
@@ -650,7 +649,7 @@ class CS2DtoBECAS(object):
             except:
                 import imp
                 shellexpander = imp.load_source('shellexpander',
-                              os.path.join(self.path_shellexpander, 'src', 'shellexpander.py'))
+                              os.path.join(os.environ['SHELLEXP_BASEDIR'], 'src', 'shellexpander.py'))
 
                 shellexpander.main(args)
                 


### PR DESCRIPTION
Added DPcoords as unkowns to the workflow. Moved path_shellexpander since the env variable is only required if shellexpander 1.5 is used.